### PR TITLE
add Gnome-shell 3.10 to supported platforms

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,5 +1,5 @@
 {
-    "shell-version": ["3.4", "3.6", "3.8"],
+    "shell-version": ["3.4", "3.6", "3.8", "3.10"],
     "uuid": "shade-inactive-windows@hepaajan.iki.fi",
     "name": "Shade Inactive Windows",
     "description": "Make inactive windows darker",


### PR DESCRIPTION
I tested "shade-inactive-windows" on gnome-shell 3.10 and it works fine. Please push to extensions.gnome.org !
looking glass did not report any errors.
