### PR TITLE
support a `shade-time' setting rather than hard-coding 0.3s

### DIFF
--- a/data/glib-2.0/schemas/fi.iki.hepaajan.shade-inactive-windows.preferences.gschema.xml
+++ b/data/glib-2.0/schemas/fi.iki.hepaajan.shade-inactive-windows.preferences.gschema.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schemalist>
+  <schema path="/fi/iki/hepaajan/shade-inactive-windows/preferences/"
+          id="fi.iki.hepaajan.shade-inactive-windows.preferences"
+          gettext-domain="gsettings-desktop-schemas">
+    <key type="i" name="shade-time">
+      <range min="0" max="1000"/>
+      <default>300</default>
+      <summary>Time in milliseconds over which shading occurs</summary>
+      <description>
+        The time over which the shading effect is applied, in milliseconds.
+      </description>
+    </key>
+  </schema>
+</schemalist>


### PR DESCRIPTION
This patch implements just about enough for users to be able to customize the shader time.  It's by no means
the finished article: I'd want to support a shade-brightness setting (and shade-desaturation, from my other patch), a tween-transition setting, and to have a ui for it in gnome-tweak-tool (a prefs.js implementation).  If this patch is OK, I will go on and do the other settings; doing the UI/prefs.js is less likely to be high on my todo-list.
