### PR TITLE
Add nominal support for Gnome-Shell 3.14

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,5 +1,5 @@
 {
-    "shell-version": ["3.4", "3.6", "3.8", "3.10", "3.12"],
+    "shell-version": ["3.4", "3.6", "3.8", "3.10", "3.12", "3.14"],
     "uuid": "shade-inactive-windows@hepaajan.iki.fi",
     "name": "Shade Inactive Windows",
     "description": "Make inactive windows darker",


### PR DESCRIPTION
I tested this extension on gnome-shell 3.14 and it works fine. Version string should reflect this so this extension is available on 3.14.
