### PR TITLE
Update tweener import for GNOME 3.38 compatibility.

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -3,7 +3,8 @@ const St = imports.gi.St;
 const Meta = imports.gi.Meta;
 const Lang = imports.lang;
 const Main = imports.ui.main;
-const Tweener = imports.ui.tweener;
+const Config = imports.misc.config;
+const Tweener = Config.PACKAGE_VERSION.startsWith("3.38") ? imports.tweener.tweener : imports.ui.tweener;
 const Clutter = imports.gi.Clutter;
 
 const SHADE_TIME = 0.3;
@@ -14,7 +15,7 @@ let on_window_created;
 const WindowShader = new Lang.Class({
     Name: 'WindowShader',
 
-    _init: function(actor) {
+    _init: function (actor) {
         this._effect = new Clutter.BrightnessContrastEffect();
         actor.add_effect(this._effect);
         this.actor = actor;
@@ -39,13 +40,13 @@ function init() {
 function enable() {
 
     function use_shader(meta_win) {
-	if (!meta_win) {
-	    return false;
-	}
-	var type = meta_win.get_window_type()
-	return (type == Meta.WindowType.NORMAL ||
-		type == Meta.WindowType.DIALOG ||
-		type == Meta.WindowType.MODAL_DIALOG);
+        if (!meta_win) {
+            return false;
+        }
+        var type = meta_win.get_window_type()
+        return (type == Meta.WindowType.NORMAL ||
+            type == Meta.WindowType.DIALOG ||
+            type == Meta.WindowType.MODAL_DIALOG);
     }
 
     function verifyShader(wa) {
@@ -56,34 +57,37 @@ function enable() {
             return;
         }
         wa._inactive_shader = new WindowShader(wa);
-        if(!wa._inactive_shader)
+        if (!wa._inactive_shader)
             return;
         if (!meta_win.has_focus()) {
             Tweener.addTween(wa._inactive_shader,
-                             { shadeLevel: 1.0,
-                               time: SHADE_TIME,
-                               transition: 'linear'
-                             });
+                {
+                    shadeLevel: 1.0,
+                    time: SHADE_TIME,
+                    transition: 'linear'
+                });
         }
     }
 
     function focus(the_window) {
-        global.get_window_actors().forEach(function(wa) {
+        global.get_window_actors().forEach(function (wa) {
             verifyShader(wa);
             if (!wa._inactive_shader)
                 return;
             if (the_window == wa.get_meta_window()) {
                 Tweener.addTween(wa._inactive_shader,
-                                 { shadeLevel: 0.0,
-                                   time: SHADE_TIME,
-                                   transition: 'linear'
-                 });
-            } else if(wa._inactive_shader.shadeLevel == 0.0) {
+                    {
+                        shadeLevel: 0.0,
+                        time: SHADE_TIME,
+                        transition: 'linear'
+                    });
+            } else if (wa._inactive_shader.shadeLevel == 0.0) {
                 Tweener.addTween(wa._inactive_shader,
-                                 { shadeLevel: 1.0,
-                                   time: SHADE_TIME,
-                                   transition: 'linear'
-                                 });
+                    {
+                        shadeLevel: 1.0,
+                        time: SHADE_TIME,
+                        transition: 'linear'
+                    });
             }
         });
     }
@@ -95,7 +99,7 @@ function enable() {
     }
     on_window_created = global.display.connect('window-created', window_created);
 
-    global.get_window_actors().forEach(function(wa) {
+    global.get_window_actors().forEach(function (wa) {
         var meta_win = wa.get_meta_window();
         if (!meta_win) {
             return;
@@ -109,13 +113,13 @@ function disable() {
     if (on_window_created) {
         global.display.disconnect(on_window_created);
     }
-    global.get_window_actors().forEach(function(wa) {
+    global.get_window_actors().forEach(function (wa) {
         var win = wa.get_meta_window();
         if (win && win._shade_on_focus) {
             win.disconnect(win._shade_on_focus);
             delete win._shade_on_focus;
         }
-        if(wa._inactive_shader) {
+        if (wa._inactive_shader) {
             wa._inactive_shader.shadeLevel = 0.0;
             wa.remove_effect(wa._inactive_shader._effect);
             delete wa._inactive_shader;

--- a/metadata.json
+++ b/metadata.json
@@ -1,5 +1,12 @@
 {
-    "shell-version": ["3.4", "3.6", "3.8", "3.10", "3.12"],
+    "shell-version": [
+        "3.4",
+        "3.6",
+        "3.8",
+        "3.10",
+        "3.12",
+        "3.38"
+    ],
     "uuid": "shade-inactive-windows@hepaajan.iki.fi",
     "name": "Shade Inactive Windows",
     "description": "Make inactive windows darker",


### PR DESCRIPTION
Update tweener module import path for GNOME 3.38 while preserving backwards compatibility for existing supported GNOME versions. Addresses issue #13 